### PR TITLE
Add Ethena original contracts

### DIFF
--- a/src/SingleAdminAccessControl.sol
+++ b/src/SingleAdminAccessControl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/interfaces/IERC5313.sol";
@@ -9,7 +9,6 @@ import "./interfaces/ISingleAdminAccessControl.sol";
  * @title SingleAdminAccessControl
  * @notice SingleAdminAccessControl is a contract that provides a single admin role
  * @notice This contract is a simplified alternative to OpenZeppelin's AccessControlDefaultAdminRules
- * @dev Changelog: update solidity versions
  */
 abstract contract SingleAdminAccessControl is
     IERC5313,

--- a/src/interfaces/ILevelMinting.sol
+++ b/src/interfaces/ILevelMinting.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
-import "./ILevelMintingEvents.sol";
+import "./IEthenaMintingEvents.sol";
 
-interface ILevelMinting is ILevelMintingEvents {
+interface IEthenaMinting is IEthenaMintingEvents {
     enum Role {
         Minter,
         Redeemer
@@ -36,12 +36,12 @@ interface ILevelMinting is ILevelMintingEvents {
         address beneficiary;
         address collateral_asset;
         uint256 collateral_amount;
-        uint256 lvusd_amount;
+        uint256 usde_amount;
     }
 
     error Duplicate();
     error InvalidAddress();
-    error InvalidlvUSDAddress();
+    error InvalidUSDeAddress();
     error InvalidZeroAddress();
     error InvalidAssetAddress();
     error InvalidCustodianAddress();

--- a/src/interfaces/ILevelMintingEvents.sol
+++ b/src/interfaces/ILevelMintingEvents.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
-interface ILevelMintingEvents {
+interface IEthenaMintingEvents {
     /// @notice Event emitted when contract receives ETH
     event Received(address, uint256);
 
-    /// @notice Event emitted when lvUSD is minted
+    /// @notice Event emitted when USDe is minted
     event Mint(
         address minter,
         address benefactor,
         address beneficiary,
         address indexed collateral_asset,
         uint256 indexed collateral_amount,
-        uint256 indexed lvusd_amount
+        uint256 indexed usde_amount
     );
 
     /// @notice Event emitted when funds are redeemed
@@ -22,7 +22,7 @@ interface ILevelMintingEvents {
         address beneficiary,
         address indexed collateral_asset,
         uint256 indexed collateral_amount,
-        uint256 indexed lvusd_amount
+        uint256 indexed usde_amount
     );
 
     /// @notice Event emitted when custody wallet is added
@@ -50,8 +50,8 @@ interface ILevelMintingEvents {
         uint256 amount
     );
 
-    /// @notice Event emitted when lvUSD is set
-    event lvUSDSet(address indexed lvUSD);
+    /// @notice Event emitted when USDe is set
+    event USDeSet(address indexed USDe);
 
     /// @notice Event emitted when the max mint per block is changed
     event MaxMintPerBlockChanged(

--- a/src/interfaces/ISingleAdminAccessControl.sol
+++ b/src/interfaces/ISingleAdminAccessControl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 interface ISingleAdminAccessControl {
     error InvalidAdminChange();

--- a/src/interfaces/IlvUSD.sol
+++ b/src/interfaces/IlvUSD.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol";
 
-interface IlvUSD is IERC20, IERC20Permit, IERC20Metadata {
+interface IUSDe is IERC20, IERC20Permit, IERC20Metadata {
     function mint(address _to, uint256 _amount) external;
 
     function burn(uint256 _amount) external;

--- a/src/interfaces/IlvUSDDefinitions.sol
+++ b/src/interfaces/IlvUSDDefinitions.sol
@@ -1,19 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
-/// @dev Changelog: changed solidity version and name
-interface IlvUSDDefinitions {
+interface IUSDeDefinitions {
     /// @notice This event is fired when the minter changes
     event MinterUpdated(address indexed newMinter, address indexed oldMinter);
 
     /// @notice Zero address not allowed
     error ZeroAddressException();
     /// @notice It's not possible to renounce the ownership
-    error OperationNotAllowed();
+    error CantRenounceOwnership();
     /// @notice Only the minter role can perform an action
     error OnlyMinter();
-    /// @notice Address is denylisted
-    error Denylisted();
-    /// @notice Address is owner
-    error IsOwner();
 }

--- a/src/lvUSD.sol
+++ b/src/lvUSD.sol
@@ -1,48 +1,26 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.19;
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
-import "./interfaces/IlvUSDDefinitions.sol";
-import "./SingleAdminAccessControl.sol";
-import "forge-std/console.sol";
+import "./interfaces/IUSDeDefinitions.sol";
 
 /**
- * @title lvUSD
- * @notice lvUSD contract
+ * @title USDe
+ * @notice Stable Coin Contract
+ * @dev Only a single approved minter can mint new tokens
  */
-contract lvUSD is
-    ERC20Burnable,
-    ERC20Permit,
-    IlvUSDDefinitions,
-    SingleAdminAccessControl
-{
-    /// @notice The role that is allowed to denylist and un-denylist addresses
-    bytes32 private constant DENYLIST_MANAGER_ROLE =
-        keccak256("DENYLIST_MANAGER_ROLE");
-
-    mapping(address => bool) public denylisted;
-
+contract USDe is Ownable2Step, ERC20Burnable, ERC20Permit, IUSDeDefinitions {
     address public minter;
 
-    constructor(
-        address admin
-    ) ERC20("Level USD", "lvUSD") ERC20Permit("lvUSD") {
+    constructor(address admin) ERC20("USDe", "USDe") ERC20Permit("USDe") {
         if (admin == address(0)) revert ZeroAddressException();
-        _grantRole(DEFAULT_ADMIN_ROLE, admin);
-        _grantRole(DENYLIST_MANAGER_ROLE, admin);
+        _transferOwnership(admin);
     }
 
-    modifier notOwner(address account) {
-        if (hasRole(DEFAULT_ADMIN_ROLE, account)) revert IsOwner();
-        _;
-    }
-
-    function setMinter(
-        address newMinter
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setMinter(address newMinter) external onlyOwner {
         emit MinterUpdated(newMinter, minter);
         minter = newMinter;
     }
@@ -52,45 +30,7 @@ contract lvUSD is
         _mint(to, amount);
     }
 
-    /**
-     * @dev Remove renounce role access from AccessControl, to prevent users from resigning from roles.
-     */
-    function renounceRole(bytes32, address) public virtual override {
-        revert OperationNotAllowed();
-    }
-
-    /**
-     * @dev Hook that is called before any transfer of tokens. This includes
-     * minting and burning. Disables transfers from or to of addresses with the DENYLISTED_ROLE role.
-     */
-
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256
-    ) internal virtual override {
-        if (denylisted[from] || denylisted[to]) {
-            revert Denylisted();
-        }
-    }
-
-    /**
-     * @notice Allows the owner (DEFAULT_ADMIN_ROLE) and denylist managers to denylist addresses.
-     * @param target The address to denylist.
-     */
-    function addToDenylist(
-        address target
-    ) external onlyRole(DENYLIST_MANAGER_ROLE) notOwner(target) {
-        denylisted[target] = true;
-    }
-
-    /**
-     * @notice Allows denylist managers to remove addresses from the denylist.
-     * @param target The address to remove from the denylist.
-     */
-    function removeFromDenylist(
-        address target
-    ) external onlyRole(DENYLIST_MANAGER_ROLE) {
-        denylisted[target] = false;
+    function renounceOwnership() public view override onlyOwner {
+        revert CantRenounceOwnership();
     }
 }


### PR DESCRIPTION
The `ethena` branch contains the original source code of the contracts that we based `lvUSD` and `LevelMinting` off of. `LevelMinting` only contains name changes, and the major modification to `lvUSD` is the addition of a denylist.

Note- the filenames are not the same as the original source code. This was intentional to make it easier to show the diffs in the code.